### PR TITLE
fix: use correct metric names

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -10,11 +10,13 @@ import (
 const namespace = "rtorrent"
 
 var (
-	rtorrentInfo       = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "info"), "rtorrent info.", []string{"name", "ip"}, nil)
-	rtorrentUp         = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "up"), "Was the last scrape of rTorrent successful.", nil, nil)
-	rtorrentDownloaded = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "downloaded_bytes_total"), "Total downloaded bytes.", nil, nil)
-	rtorrentUploaded   = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "uploaded_bytes_total"), "Total uploaded bytes.", nil, nil)
-	rtorrentTorrents   = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "torrents_total"), "Torrent count by view.", []string{"view", "label"}, nil)
+	rtorrentInfo            = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "info"), "rtorrent info.", []string{"name", "ip"}, nil)
+	rtorrentUp              = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "up"), "Was the last scrape of rTorrent successful.", nil, nil)
+	rtorrentDownloaded      = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "downloaded_bytes"), "Total downloaded bytes, deprecated", nil, nil)
+	rtorrentDownloadedTotal = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "downloaded_bytes_total"), "Total downloaded bytes", nil, nil)
+	rtorrentUploaded        = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "uploaded_bytes"), "Total uploaded bytes, deprecated", nil, nil)
+	rtorrentUploadedTotal   = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "uploaded_bytes_total"), "Total uploaded bytes", nil, nil)
+	rtorrentTorrents        = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "torrents_total"), "Torrent count by view.", []string{"view", "label"}, nil)
 )
 
 // Exporter returns a prometheus.Collector that gathers rTorrent metrics.
@@ -63,6 +65,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 
 	}
 	ch <- prometheus.MustNewConstMetric(rtorrentDownloaded, prometheus.CounterValue, float64(downloaded))
+	ch <- prometheus.MustNewConstMetric(rtorrentDownloadedTotal, prometheus.CounterValue, float64(downloaded))
 
 	uploaded, err := e.Client.UpTotal()
 	if err != nil {
@@ -70,6 +73,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 		return 1
 	}
 	ch <- prometheus.MustNewConstMetric(rtorrentUploaded, prometheus.CounterValue, float64(uploaded))
+	ch <- prometheus.MustNewConstMetric(rtorrentUploadedTotal, prometheus.CounterValue, float64(uploaded))
 
 	for name, view := range map[string]rtorrent.View{
 		"main":    rtorrent.ViewMain,

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -12,8 +12,8 @@ const namespace = "rtorrent"
 var (
 	rtorrentInfo       = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "info"), "rtorrent info.", []string{"name", "ip"}, nil)
 	rtorrentUp         = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "up"), "Was the last scrape of rTorrent successful.", nil, nil)
-	rtorrentDownloaded = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "downloaded_bytes"), "Total downloaded bytes.", nil, nil)
-	rtorrentUploaded   = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "uploaded_bytes"), "Total uploaded bytes.", nil, nil)
+	rtorrentDownloaded = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "downloaded_bytes_total"), "Total downloaded bytes.", nil, nil)
+	rtorrentUploaded   = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "uploaded_bytes_total"), "Total uploaded bytes.", nil, nil)
 	rtorrentTorrents   = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "torrents_total"), "Torrent count by view.", []string{"view", "label"}, nil)
 )
 


### PR DESCRIPTION
Prometheus UI gives a warning for ambiguous metric type